### PR TITLE
Deprecate # as comment symbol due to RFC 3597 requirements

### DIFF
--- a/pydnstest/scenario.py
+++ b/pydnstest/scenario.py
@@ -718,7 +718,7 @@ def get_next(file_in, skip_empty = True):
                 escaped = not escaped
             if not escaped and line[i] == '"':
                 quoted = not quoted
-            if line[i] in (';', '#') and not quoted:
+            if line[i] in (';') and not quoted:
                 line = line[0:i]
                 break
             if line[i] != '\\':


### PR DESCRIPTION
Hello!

I'm playing with https://tools.ietf.org/html/rfc3597 and unknown RR encoding. For this purposes I need to create something like this in my scenario:

```
shortsubdomain.mydomain.io. 333 IN TYPE110 \# 34 21536176652074686520496e7465726e 6574207769746820436c6f7564466c61 7265
```

And right now I'm getting this error:

```
    stage, _ = scenario.parse_file(fileinput.input(name))
  File "/Users/pavel/linux_venv/local/lib/python2.7/site-packages/pydnstest/scenario.py", line 845, in parse_file
    raise Exception('%s#%d: %s' % (file_in.filename(), file_in.lineno(), str(e)))
Exception: system/tests/unknown-type.rpl#16: Text input ended unexpectedly.
Makefile:218: recipe for target 'systemv2' failed
make: *** [systemv2] Error 1
```

With help from @vavrusa I've prepared this PR and I'd like to ask you to deprecate "#" as comment symbol.

Thank you!
