### PR TITLE
Default to `python2` instead of plain `python`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DAEMON ?= kresd
 TEMPLATE ?= template/kresd.j2
 CONFIG ?= config
 
-PYTHON := python
+PYTHON := python2
 LIBEXT := .so
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM),Darwin)

--- a/deckard.py
+++ b/deckard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 import os
 import fileinput

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from distutils.core import setup
 


### PR DESCRIPTION
This fixes installations where python3 is the default.